### PR TITLE
65: Fix broken placeholder images

### DIFF
--- a/frontend/components/democracy/Elections.jsx
+++ b/frontend/components/democracy/Elections.jsx
@@ -15,8 +15,7 @@ class ElectionsComponent extends React.Component {
     checkImage = async (path) => {
         try {
             const res = await axios.get(path);
-            console.log(res.data.slice(0, 15));
-            if (res.data.slice(0, 15) !== "<!DOCTYPE html>") {
+            if (res.data.slice(0, 15).toLowerCase() !== "<!doctype html>") {
                 return true;
             } else {
                 return false;

--- a/frontend/components/democracy/RoleHeader.jsx
+++ b/frontend/components/democracy/RoleHeader.jsx
@@ -16,8 +16,7 @@ class RoleHeader extends React.Component {
     checkImage = async (path) => {
         try {
             const res = await axios.get(path);
-            console.log(res.data.slice(0, 15));
-            if (res.data.slice(0, 15) !== "<!DOCTYPE html>") {
+            if (res.data.slice(0, 15).toLowerCase() !== "<!doctype html>") {
                 return true;
             } else {
                 return false;

--- a/frontend/components/getInvolved/SSCHeader.jsx
+++ b/frontend/components/getInvolved/SSCHeader.jsx
@@ -23,8 +23,7 @@ class SSCHeader extends React.Component {
     checkImage = async (path) => {
         try {
             const res = await axios.get(path);
-            console.log(res.data.slice(0, 15));
-            if (res.data.slice(0, 15) !== "<!DOCTYPE html>") {
+            if (res.data.slice(0, 15).toLowerCase() !== "<!doctype html>") {
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
## Description:

Fixes placeholder images by fixing the logic for `checkImage`

## Screenshots:

<details>
<summary>Open/Close screnshots</summary>

![image](https://github.com/NedReid/ButlerJCRWebsite/assets/56114384/65619196-1d53-4ce3-914b-54573361d016)

</details>

## Merge checklist:

-   [x] I have reviewed my own code
-   [x] I have added screenshots of any UI changes
-   [x] I haven't added any packages that significantly increased the
        bundle size (or justified them if so)
-   [x] I have made sure any UI changes work on mobile
-   [x] I have ran `npm run lint` and there were no errors
-   [x] I have rebased on the latest version of main
