### PR TITLE
70: Fix styling of header for spaces on mobile

### DIFF
--- a/frontend/components/global/Header.jsx
+++ b/frontend/components/global/Header.jsx
@@ -181,7 +181,10 @@ class Header extends React.Component {
                                                                     className="w-full text-center  px-3 py-1 hover:animate-pingOnce bg-orange-800 text-white transition ease-out hover:z-50 hover:bg-orange-400 duration-300"
                                                                 >
                                                                     <p className="text-center w-full">
-                                                                        {subMenu.title}
+                                                                        {subMenu.title.replace(
+                                                                            "<br/>",
+                                                                            " ",
+                                                                        )}
                                                                     </p>
                                                                 </Link>
                                                             )}


### PR DESCRIPTION
## Description:

Fixes header buttons for bookable and study spaces on mobile

## Screenshots:

<details>
<summary>Open/Close screnshots</summary>

![image](https://github.com/user-attachments/assets/badbc41a-fda8-4431-af4e-74e3b81b47bd)

</details>

## Merge checklist:

-   [x] I have reviewed my own code
-   [x] I have added screenshots of any UI changes
-   [x] I haven't added any packages that significantly increased the
        bundle size (or justified them if so)
-   [x] I have made sure any UI changes work on mobile
-   [x] I have ran `npm run lint` and there were no errors
-   [x] I have rebased on the latest version of main
